### PR TITLE
Fixes for ffmpeg and Mac OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 # safe.  We call malloc, and older Linux versions only linked in the thread-safe
 # malloc if -pthread is specified.
 
+SONAME=soname
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+  SONAME=install_name
+endif
 CFLAGS=-Wall -g -ansi -fPIC -pthread
 #CFLAGS=-Wall -O2 -ansi -fPIC -pthread
 LIB_TAG=0.1.18
@@ -24,7 +29,7 @@ main.o: main.c sonic.h wave.h
 	$(CC) $(CFLAGS) -c main.c
 
 libsonic.so.$(LIB_TAG): sonic.o
-	$(CC) $(CFLAGS) -shared -Wl,-soname,libsonic.so.0 sonic.o -o libsonic.so.$(LIB_TAG)
+	$(CC) $(CFLAGS) -shared -Wl,-$(SONAME),libsonic.so.0 sonic.o -o libsonic.so.$(LIB_TAG)
 	ln -sf libsonic.so.$(LIB_TAG) libsonic.so
 	ln -sf libsonic.so.$(LIB_TAG) libsonic.so.0
 

--- a/wave.c
+++ b/wave.c
@@ -208,8 +208,8 @@ static int readHeader(
     data = readInt(file); /* 04 - how big is the rest of this file? */
     expectString(file, "WAVE"); /* 08 - WAVE */
     expectString(file, "fmt "); /* 12 - fmt */
-    data = readInt(file); /* 16 - size of this chunk */
-    if(data != 16) {
+    int chunkSize = readInt(file); /* 16 or 18 - size of this chunk */
+    if(chunkSize != 16 && chunkSize != 18) {
         fprintf(stderr, "Only basic wave files are supported\n");
         return 0;
     }
@@ -226,6 +226,9 @@ static int readHeader(
     if(data != 16) {
         fprintf(stderr, "Only 16 bit PCM wave files are supported\n");
         return 0;
+    }
+    if (chunkSize == 18) { /* ffmpeg writes 18, and so has 2 extra bytes here */
+        data = readShort(file);
     }
     expectString(file, "data"); /* 36 - data */
     readInt(file); /* 40 - how big is this data chunk */


### PR DESCRIPTION
- Made the Makefile work under OSX 10.8
- Made the WAV header parsing work with what ffmpeg outputs: https://ffmpeg.org/trac/ffmpeg/ticket/1843
