### PR TITLE
Add $(FFTLIB) to link command for libsonic.so.$(LIB_TAG) target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ spectrogram.o: spectrogram.c sonic.h
 	$(CC) $(CFLAGS) -c spectrogram.c
 
 libsonic.so.$(LIB_TAG): $(OBJ)
-	$(CC) $(CFLAGS) -shared -Wl,-$(SONAME),libsonic.so.0 $(OBJ) -o libsonic.so.$(LIB_TAG)
+	$(CC) $(CFLAGS) -shared -Wl,-$(SONAME),libsonic.so.0 $(OBJ) -o libsonic.so.$(LIB_TAG) $(FFTLIB)
 	ln -sf libsonic.so.$(LIB_TAG) libsonic.so
 	ln -sf libsonic.so.$(LIB_TAG) libsonic.so.0
 


### PR DESCRIPTION
Added *FFTW* option to link command for so library so that it's linked in when compiling programs 
Otherwise compilation fails unless `-lfftw3` is added when compiling.
This causes e.g. configure script for *espeak-ng* to fail to detect sonic (because of undefined *FFTW* symbols errors).