### PR TITLE
Remove unused period arg from prevPeriodBetter

### DIFF
--- a/sonic.c
+++ b/sonic.c
@@ -652,7 +652,7 @@ static int findPitchPeriodInRange(short* samples, int minPeriod, int maxPeriod,
 /* At abrupt ends of voiced words, we can have pitch periods that are better
    approximated by the previous pitch period estimate.  Try to detect this case.
  */
-static int prevPeriodBetter(sonicStream stream, int period, int minDiff,
+static int prevPeriodBetter(sonicStream stream, int minDiff,
                             int maxDiff, int preferNewPeriod) {
   if (minDiff == 0 || stream->prevPeriod == 0) {
     return 0;
@@ -718,7 +718,7 @@ static int findPitchPeriod(sonicStream stream, short* samples,
       }
     }
   }
-  if (prevPeriodBetter(stream, period, minDiff, maxDiff, preferNewPeriod)) {
+  if (prevPeriodBetter(stream, minDiff, maxDiff, preferNewPeriod)) {
     retPeriod = stream->prevPeriod;
   } else {
     retPeriod = period;


### PR DESCRIPTION
Function prevPeriodBetter has unused parameter "period". In projects with strict compiler settings or with static analysis tools in build pipelines unused parameters usually are treated as errors. Currently, to get sonic sources compiled directly as a part of such project, one needs either to patch sonic.c or configure the compiler/sa tool to treat this file specially. While it is debatable whether a public C library should consider unacceptable what essentially is a warning-level error and I don't know the "official" Sonic's position on that, I think that in this particular case there is no need to keep the unused parameter in function's interface. This PR removes this unused parameter.