### PR TITLE
Reinstate commits reverted in google3 sync

### DIFF
--- a/sonic.c
+++ b/sonic.c
@@ -391,7 +391,7 @@ static int allocateStreamBuffers(sonicStream stream, int sampleRate,
   /* Allocate 25% more than needed so we hopefully won't grow. */
   stream->pitchBufferSize = maxRequired + (maxRequired >> 2);
   stream->pitchBuffer =
-      (short*)sonicCalloc(maxRequired, sizeof(short) * numChannels);
+      (short*)sonicCalloc(stream->pitchBufferSize, sizeof(short) * numChannels);
   if (stream->pitchBuffer == NULL) {
     sonicDestroyStream(stream);
     return 0;
@@ -887,15 +887,12 @@ static int moveNewSamplesToPitchBuffer(sonicStream stream,
                                        int originalNumOutputSamples) {
   int numSamples = stream->numOutputSamples - originalNumOutputSamples;
   int numChannels = stream->numChannels;
+  int pitchBufferSize = stream->pitchBufferSize;
 
-  if (stream->numPitchSamples + numSamples > stream->pitchBufferSize) {
-    int pitchBufferSize = stream->pitchBufferSize;
+  if (stream->numPitchSamples + numSamples > pitchBufferSize) {
     stream->pitchBufferSize += (pitchBufferSize >> 1) + numSamples;
-    stream->pitchBuffer = (short*)sonicRealloc(
-        stream->pitchBuffer,
-        pitchBufferSize,
-        stream->pitchBufferSize,
-        sizeof(short) * numChannels);
+    stream->pitchBuffer = (short*)sonicRealloc(stream->pitchBuffer,
+        pitchBufferSize, stream->pitchBufferSize, sizeof(short) * numChannels);
   }
   memcpy(stream->pitchBuffer + stream->numPitchSamples * numChannels,
          stream->outputBuffer + originalNumOutputSamples * numChannels,

--- a/sonic.h
+++ b/sonic.h
@@ -251,8 +251,6 @@ struct sonicBitmapStruct {
   int numCols;
 };
 
-typedef struct sonicBitmapStruct* sonicBitmap;
-
 /* Enable coomputation of a spectrogram on the fly. */
 void sonicComputeSpectrogram(sonicStream stream);
 

--- a/spectrogram.c
+++ b/spectrogram.c
@@ -7,7 +7,7 @@
 */
 
 #ifdef  KISS_FFT
-#include <stddef.h>  /* kiss_fft.h failes to load this */
+#include <stddef.h>  /* kiss_fft.h fails to load this */
 #include <kiss_fft.h>
 #include <kiss_fft_impl.h>
 #else
@@ -370,3 +370,8 @@ int sonicWritePGM(sonicBitmap bitmap, char* fileName) {
   fclose(file);
   return 1;
 }
+
+#ifdef	MAIN
+main(){
+}
+#endif


### PR DESCRIPTION
Commits 9a8d05dc0baa9159fc322dd9905a04e23b161337 ("Fix to initial allocation of pitch buffer size") and 0e72cd4c3dc34c851232e1f74317c72d9d34789f ("Cleaning up spectrogram code for speedy") were (at least partially) reverted in when syncing to google3 in commit 3ad514619a5bcb573af014d7edada34e42e5ecc2.

I reapplied those commits to HEAD, though I didn't include the Makefile changes that were in 0e72cd4c3dc34c851232e1f74317c72d9d34789f because I'm not familiar enough with it to know if that's the right thing to do. I also removed a duplicate typedef for `sonicBitmap`.