### PR TITLE
Fix integer overflow in insertPitchPeriod / enlargeOutputBufferIfNeeded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,11 @@ check:
 test: sonic_unit_test
 	./sonic_unit_test
 
-sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
-	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/overflow_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
+	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/overflow_test.c tests/genwave.c sonic.c -lm
 
 coverage:
-	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/overflow_test.c tests/genwave.c sonic.c -lm
 	./sonic_coverage
 	gcov -o sonic_coverage-sonic.gcno sonic.c
 

--- a/sonic.c
+++ b/sonic.c
@@ -460,12 +460,23 @@ void sonicSetNumChannels(sonicStream stream, int numChannels) {
   allocateStreamBuffers(stream, stream->sampleRate, numChannels);
 }
 
-/* Enlarge the output buffer if needed. */
-static int enlargeOutputBufferIfNeeded(sonicStream stream, int numSamples) {
+/* Enlarge the output buffer if needed. Not static: exercised directly by
+   the white-box overflow tests in tests/overflow_test.c. */
+int enlargeOutputBufferIfNeeded(sonicStream stream, int numSamples) {
   int outputBufferSize = stream->outputBufferSize;
+  int growth;
 
-  if (stream->numOutputSamples + numSamples > outputBufferSize) {
-    stream->outputBufferSize += (outputBufferSize >> 1) + numSamples;
+  if (numSamples < 0) {
+    return 0;
+  }
+  /* Written as a subtraction, not "numOutputSamples + numSamples", so the
+     comparison itself can't signed-overflow when numSamples is huge. */
+  if (stream->numOutputSamples > outputBufferSize - numSamples) {
+    growth = outputBufferSize >> 1;
+    if (numSamples > INT_MAX - outputBufferSize - growth) {
+      return 0;
+    }
+    stream->outputBufferSize = outputBufferSize + growth + numSamples;
     stream->outputBuffer = (short*)sonicRealloc(
         stream->outputBuffer, outputBufferSize, stream->outputBufferSize,
         sizeof(short) * stream->numChannels);
@@ -1039,10 +1050,13 @@ static int skipPitchPeriod(sonicStream stream, short* samples, float speed,
   return newSamples;
 }
 
-/* Insert a pitch period, and determine how much input to copy directly. */
-static int insertPitchPeriod(sonicStream stream, short* samples, float speed,
-                             int period) {
+/* Insert a pitch period, and determine how much input to copy directly. Not
+   static: exercised directly by the white-box overflow tests in
+   tests/overflow_test.c. */
+int insertPitchPeriod(sonicStream stream, short* samples, float speed,
+                      int period) {
   long newSamples;
+  long totalSamples;
   short* out;
   int numChannels = stream->numChannels;
 
@@ -1051,7 +1065,14 @@ static int insertPitchPeriod(sonicStream stream, short* samples, float speed,
   } else {
     newSamples = period;
   }
-  if (!enlargeOutputBufferIfNeeded(stream, period + newSamples)) {
+  /* period + newSamples is computed in long above, but
+     enlargeOutputBufferIfNeeded takes an int; reject here instead of
+     silently truncating a huge period into a small/negative int. */
+  totalSamples = (long)period + newSamples;
+  if (totalSamples < 0 || totalSamples > INT_MAX) {
+    return 0;
+  }
+  if (!enlargeOutputBufferIfNeeded(stream, (int)totalSamples)) {
     return 0;
   }
   out = stream->outputBuffer + stream->numOutputSamples * numChannels;

--- a/tests/overflow_test.c
+++ b/tests/overflow_test.c
@@ -1,0 +1,88 @@
+/* Sonic library
+   Copyright 2026
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+#include "sonic.h"
+
+#include <limits.h>
+#include <stdio.h>
+
+#define SAMPLE_RATE 44100
+#define NUM_CHANNELS 1
+
+/* enlargeOutputBufferIfNeeded and insertPitchPeriod are not declared static
+   in sonic.c specifically so these white-box tests can call them directly,
+   without going through the public streaming API to reach the overflow
+   paths. They are not part of the public sonic.h contract. */
+int enlargeOutputBufferIfNeeded(sonicStream stream, int numSamples);
+int insertPitchPeriod(sonicStream stream, short* samples, float speed,
+                      int period);
+
+int sonicTestEnlargeOutputBufferRejectsOverflow(void) {
+    sonicStream stream;
+    int result;
+
+    stream = sonicCreateStream(SAMPLE_RATE, NUM_CHANNELS);
+    if (stream == NULL) {
+        fprintf(stderr, "sonicCreateStream failed\n");
+        return 0;
+    }
+    /* A request this large can't be satisfied; the guard must fail cleanly
+       instead of signed-overflowing the internal buffer size arithmetic. */
+    result = enlargeOutputBufferIfNeeded(stream, INT_MAX);
+    sonicDestroyStream(stream);
+    if (result != 0) {
+        fprintf(stderr,
+                "enlargeOutputBufferIfNeeded should reject an overflowing request\n");
+        return 0;
+    }
+    return 1;
+}
+
+int sonicTestEnlargeOutputBufferAcceptsNormalRequest(void) {
+    sonicStream stream;
+    int result;
+
+    stream = sonicCreateStream(SAMPLE_RATE, NUM_CHANNELS);
+    if (stream == NULL) {
+        fprintf(stderr, "sonicCreateStream failed\n");
+        return 0;
+    }
+    result = enlargeOutputBufferIfNeeded(stream, 128);
+    sonicDestroyStream(stream);
+    if (result != 1) {
+        fprintf(stderr,
+                "enlargeOutputBufferIfNeeded should accept a normal request\n");
+        return 0;
+    }
+    return 1;
+}
+
+int sonicTestInsertPitchPeriodRejectsOverflow(void) {
+    sonicStream stream;
+    short dummy[1];
+    int result;
+
+    stream = sonicCreateStream(SAMPLE_RATE, NUM_CHANNELS);
+    if (stream == NULL) {
+        fprintf(stderr, "sonicCreateStream failed\n");
+        return 0;
+    }
+    dummy[0] = 0;
+    /* period this large makes period + newSamples overflow INT_MAX before
+       the fix, which used to truncate silently at the
+       enlargeOutputBufferIfNeeded call boundary. The function must return
+       failure before touching samples, so a 1-element buffer is safe here. */
+    result = insertPitchPeriod(stream, dummy, 1.0f, INT_MAX);
+    sonicDestroyStream(stream);
+    if (result != 0) {
+        fprintf(stderr,
+                "insertPitchPeriod should reject an overflowing period\n");
+        return 0;
+    }
+    return 1;
+}

--- a/tests/runtests.c
+++ b/tests/runtests.c
@@ -20,6 +20,9 @@ int main(int argc, char** argv) {
   assert(sonicTestParameters());
   assert(sonicTestFlush());
   assert(sonicTestSimpleProcessing());
+  assert(sonicTestEnlargeOutputBufferRejectsOverflow());
+  assert(sonicTestEnlargeOutputBufferAcceptsNormalRequest());
+  assert(sonicTestInsertPitchPeriodRejectsOverflow());
   printf("All tests passed.\n");
   return 0;
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -17,6 +17,9 @@ int sonicTestStreamCreation(void);
 int sonicTestParameters(void);
 int sonicTestFlush(void);
 int sonicTestSimpleProcessing(void);
+int sonicTestEnlargeOutputBufferRejectsOverflow(void);
+int sonicTestEnlargeOutputBufferAcceptsNormalRequest(void);
+int sonicTestInsertPitchPeriodRejectsOverflow(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes #50.

`period + newSamples` is computed correctly in `long` inside `insertPitchPeriod`, but is truncated to `int` when passed into `enlargeOutputBufferIfNeeded`'s `int numSamples` parameter. Inside that function, the `int` addition `numOutputSamples + numSamples` and the buffer-growth calculation can also signed-overflow — both paths can end with a too-small allocation followed by writes sized for the original, much larger sample count (heap buffer overflow), matching the AFL findings in #43.

Fix:
- `insertPitchPeriod` now checks the `long` sum against `INT_MAX` before truncating, returning failure through the existing `0`-return convention instead of truncating silently.
- `enlargeOutputBufferIfNeeded` checks its own addition for overflow before applying it, same failure convention.

Both functions are no longer `static` (not added to the public `sonic.h` API) so `tests/overflow_test.c` can call them directly with values chosen to hit the overflow guards, since reproducing this through the public streaming API would require gigabytes of audio input.

`make test` passes, no new warnings.