### PR TITLE
Clamp float samples to [-1, 1] before scaling to short

### DIFF
--- a/sonic.c
+++ b/sonic.c
@@ -507,6 +507,7 @@ static int addFloatSamplesToInputBuffer(sonicStream stream,
                                         const float* samples, int numSamples) {
   short* buffer;
   int count = numSamples * stream->numChannels;
+  float sample;
 
   if (numSamples == 0) {
     return 1;
@@ -516,7 +517,14 @@ static int addFloatSamplesToInputBuffer(sonicStream stream,
   }
   buffer = stream->inputBuffer + stream->numInputSamples * stream->numChannels;
   while (count--) {
-    *buffer++ = (*samples++) * 32767.0f;
+    /* sonic.h documents samples must be in [-1, 1], but converting an
+       out-of-range float to short is undefined behavior, not just lossy, so
+       clamp defensively like every other input path in this file does.
+       CLAMP expands its argument multiple times, so *samples++ can't be
+       passed directly -- that would increment samples more than once. */
+    sample = CLAMP(*samples, -1.0f, 1.0f);
+    samples++;
+    *buffer++ = sample * 32767.0f;
   }
   updateNumInputSamples(stream, numSamples);
   return 1;

--- a/tests/input_clamping_test.c
+++ b/tests/input_clamping_test.c
@@ -81,6 +81,39 @@ int sonicTestInputClamping(void) {
   return 1;
 }
 
+/* Verify out-of-range float samples are clamped to [-1, 1] before being
+   scaled to short, instead of undergoing undefined-behavior float-to-short
+   conversion. With default speed/pitch/rate/volume (all 1.0), sonic takes a
+   bit-exact passthrough path, so the clamp is the only thing that can
+   explain the output values here. */
+int sonicTestFloatSampleClamping(void) {
+  sonicStream stream = sonicCreateStream(44100, 1);
+  float input[4];
+  short output[4];
+  int samplesRead;
+
+  input[0] = 2.0f;
+  input[1] = -3.0f;
+  input[2] = 1.0f;
+  input[3] = -1.0f;
+  if (!sonicWriteFloatToStream(stream, input, 4)) {
+    return 0;
+  }
+  if (!sonicFlushStream(stream)) {
+    return 0;
+  }
+  samplesRead = sonicReadShortFromStream(stream, output, 4);
+  if (samplesRead != 4) {
+    return 0;
+  }
+  if (output[0] != 32767 || output[1] != -32767 || output[2] != 32767 ||
+      output[3] != -32767) {
+    return 0;
+  }
+  sonicDestroyStream(stream);
+  return 1;
+}
+
 /* Used as the read buffer length when processing audio. */
 #define READ_BUF_LEN 1000
 

--- a/tests/runtests.c
+++ b/tests/runtests.c
@@ -20,6 +20,7 @@ int main(int argc, char** argv) {
   assert(sonicTestParameters());
   assert(sonicTestFlush());
   assert(sonicTestSimpleProcessing());
+  assert(sonicTestFloatSampleClamping());
   printf("All tests passed.\n");
   return 0;
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -17,6 +17,7 @@ int sonicTestStreamCreation(void);
 int sonicTestParameters(void);
 int sonicTestFlush(void);
 int sonicTestSimpleProcessing(void);
+int sonicTestFloatSampleClamping(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes #48.

`addFloatSamplesToInputBuffer` multiplied each input float by `32767.0f` and assigned straight into a `short`, with no range check. `sonic.h` documents that values passed to `sonicWriteFloatToStream` must be in `[-1, 1]`, but nothing enforced it, and converting an out-of-range float to an integer type it doesn't fit is undefined behavior in C (6.3.1.4), not just lossy truncation.

Every other input path in this file already clamps defensively instead of trusting the caller (`sonicSetVolume`, `sonicSetSpeed`, `sonicSetPitch`, `sonicSetRate`, `sonicSetSampleRate`, `sonicSetNumChannels`, and `scaleSamples`'s int16 output) — this was the one exception.

Fix: clamp with the existing `CLAMP` macro before the multiply.

Adds `sonicTestFloatSampleClamping` to `tests/input_clamping_test.c` — writes floats outside `[-1, 1]`, reads back through the bit-exact passthrough path that default stream settings take, and checks the output stays within `[-32767, 32767]`.

`make test` passes, no new warnings.