### PR TITLE
Add GitHub Actions CI and SECURITY.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,15 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build-and-test:
@@ -10,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Build
@@ -19,6 +28,7 @@ jobs:
 
   strict-and-sanitized:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Run unit tests with -Werror and sanitizers
@@ -26,15 +36,24 @@ jobs:
 
   fuzz-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Build fuzz target
         run: make fuzz
       - name: Run bounded fuzz smoke test
         run: ./fuzz_sonic -max_total_time=120
+      - name: Upload fuzz crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crashes
+          path: 'crash-*'
+          if-no-files-found: ignore
 
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Build and run coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,15 @@ jobs:
         run: make fuzz
       - name: Run bounded fuzz smoke test
         run: ./fuzz_sonic -max_total_time=120
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run coverage
+        run: make coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: '*.gcov'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: make
+      - name: Run unit tests
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run unit tests with -Werror and sanitizers
         run: make CC=clang CFLAGS="-Wall -Werror -g -fsanitize=address,undefined -fno-omit-frame-pointer" test
+
+  fuzz-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build fuzz target
+        run: make fuzz
+      - name: Run bounded fuzz smoke test
+        run: ./fuzz_sonic -max_total_time=120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,10 @@ jobs:
         run: make
       - name: Run unit tests
         run: make test
+
+  strict-and-sanitized:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run unit tests with -Werror and sanitizers
+        run: make CC=clang CFLAGS="-Wall -Werror -g -fsanitize=address,undefined -fno-omit-frame-pointer" test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,16 @@
 *.obj
+*.o
+*.a
+*.so
+*.so.*
+*.dylib
+sonic
+sonic_lite
+sonic_experimental
+sonic_unit_test
+sonic_coverage
+fuzz_sonic
+*.gcda
+*.gcno
+*.gcov
+crash-*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you've found a security vulnerability in Sonic, please
+report it privately using GitHub's security advisory feature:
+
+1. Go to the [Security tab](../../security) of this repository.
+2. Click "Report a vulnerability".
+3. Fill in as much detail as you can: affected version/commit, a
+   reproduction case, and the potential impact.
+
+This lets us investigate and prepare a fix before the issue is publicly
+disclosed. Please do not report security vulnerabilities through public
+GitHub issues.
+
+If you're not sure whether something qualifies as a security issue (as
+opposed to a regular bug), it's fine to open a normal issue instead --
+we'd rather see it than have it go unreported.
+
+## Supported Versions
+
+Sonic does not currently follow a formal release/support schedule; the
+`master` branch is the actively maintained version. Fixes are made
+against `master` and backported to a tagged release only if a
+maintainer decides to cut one.

--- a/sonic.c
+++ b/sonic.c
@@ -928,7 +928,7 @@ static int findSincCoefficient(int i, int ratio, int width) {
   int leftVal = sincTable[left];
   int rightVal = sincTable[right];
 
-  return ((leftVal * (width - position) + rightVal * position) << 1) / width;
+  return ((leftVal * (width - position) + rightVal * position) * 2) / width;
 }
 
 /* Return 1 if value >= 0, else -1.  This represents the sign of value. */

--- a/tests/fuzz_main.c
+++ b/tests/fuzz_main.c
@@ -36,9 +36,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         if (numSamples > 0) {
             sonicWriteShortToStream(stream, (short*)(Data + 4), numSamples);
             
-            /* Read out some data to exercise processing */
+            /* Read out some data to exercise processing. maxSamples in
+               sonicReadShortFromStream is a per-channel count, so the cap
+               passed here must account for numChannels or a stereo stream
+               overflows outBuffer (sizeof(outBuffer) / sizeof(short) is
+               1024 shorts total, not 1024 per channel). */
             short outBuffer[1024];
-            while (sonicReadShortFromStream(stream, outBuffer, 1024) > 0) {}
+            int maxSamplesPerChannel = 1024 / numChannels;
+            while (sonicReadShortFromStream(stream, outBuffer,
+                                            maxSamplesPerChannel) > 0) {}
         }
     }
     

--- a/tests/sonic_api_test.c
+++ b/tests/sonic_api_test.c
@@ -58,8 +58,7 @@ int sonicTestParameters(void) {
 int sonicTestFlush(void) {
     sonicStream stream = sonicCreateStream(SAMPLE_RATE, 1);
     short samples[100] = {0};
-    short outSamples[100];
-    
+
     sonicWriteShortToStream(stream, samples, 100);
     sonicFlushStream(stream);
     


### PR DESCRIPTION
Closes #59.

The repo had no CI at all -- no `.github/workflows`, nothing -- despite `make test`, `make coverage`, and `make fuzz` all already existing and working locally. This adds a `.github/workflows/ci.yml` with four jobs, all invoking those existing Makefile targets rather than inventing new build logic:

- **`build-and-test`** -- matrix `[ubuntu-latest, macos-latest]`, `make && make test`. Covers both Makefile Linux/Darwin branches and both platforms' default compilers (gcc, Apple clang) without an explicit compiler matrix.
- **`strict-and-sanitized`** -- `ubuntu-latest`, `clang`, `-Werror` + ASan/UBSan. Targets exactly the bug class already found and fixed in #50, #48, and one more (below).
- **`fuzz-smoke`** -- `ubuntu-latest`, a 2-minute bounded run of the existing `tests/fuzz_main.c` harness via `make fuzz`. This is how #43's three bugs were originally found; previously only run manually. Uploads the crash reproducer as an artifact if it ever goes red.
- **`coverage`** -- `ubuntu-latest`, runs `make coverage`, uploads the `.gcov` output as a build artifact. No external service/token, since a PR from a fork can't provision this repo's secrets.

Also adds `SECURITY.md` -- points reporters at GitHub's private security advisory flow. And extends `.gitignore`, which previously only covered `*.obj`, to cover the various build artifacts (`.o`, `.a`, `.so*`, test/coverage/fuzz binaries, `.gcda`/`.gcno`/`.gcov`) these new jobs' `make` invocations produce.

**Three pre-existing bugs were blocking these jobs from being meaningfully green, fixed here rather than worked around:**
1. An unused-variable warning in `tests/sonic_api_test.c` (blocked `-Werror`).
2. `findSincCoefficient` left-shifted a value that can be negative (`sincTable` has negative entries) -- undefined behavior in C. Fixed with the behaviorally-identical `* 2`.
3. `tests/fuzz_main.c`'s read loop passed a fixed `maxSamples` cap without accounting for `numChannels`, even though that parameter is a per-channel count throughout `sonic.c` -- a real stack-buffer-overflow on stereo streams, confirmed via a symbolized ASan trace. This is a harness bug, not a `sonic.c` bug; without the fix, every stereo-generating fuzz-smoke run would crash on the harness itself rather than finding real issues.

Deliberately out of scope, tracked separately: formatting/clang-format (#64, since enforcing one now means reformatting every source file in this PR), Java build/test setup (#65, since `Sonic.java`/`Main.java` have no build system to run in CI yet), and #66, a separate pre-existing signed-integer-overflow in `interpolate()` plus the `make fuzz` target's lack of ASan/UBSan instrumentation. `strict-and-sanitized` does compile and exercise that same code path (via `tests/input_clamping_test.c`'s rate-change tests) but doesn't currently trip it -- the fixture's amplitude stays under the threshold that triggers the overflow, not because the path is untested. Worth knowing if that fixture's amplitude ever changes.

`make`, `make test`, the sanitized `make CC=clang CFLAGS=... test`, `make fuzz` + a 2-minute ASan+UBSan smoke run, and `make coverage` all verified locally before this PR was opened, and independently re-verified in a second pass against the final HEAD.
