### PR TITLE
Fix signed-integer-overflow UB in interpolate()'s FIR accumulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,11 @@ check:
 test: sonic_unit_test
 	./sonic_unit_test
 
-sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
-	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/interpolate_overflow_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
+	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/interpolate_overflow_test.c tests/genwave.c sonic.c -lm
 
 coverage:
-	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/interpolate_overflow_test.c tests/genwave.c sonic.c -lm
 	./sonic_coverage
 	gcov -o sonic_coverage-sonic.gcno sonic.c
 

--- a/sonic.c
+++ b/sonic.c
@@ -931,41 +931,42 @@ static int findSincCoefficient(int i, int ratio, int width) {
   return ((leftVal * (width - position) + rightVal * position) << 1) / width;
 }
 
-/* Return 1 if value >= 0, else -1.  This represents the sign of value. */
-static int getSign(int value) { return value >= 0 ? 1 : -1; }
-
-/* Interpolate the new output sample. */
-static short interpolate(sonicStream stream, short* in, int oldSampleRate,
-                         int newSampleRate) {
-  /* Compute N-point sinc FIR-filter here.  Clip rather than overflow. */
+/* Interpolate the new output sample. Not static: exercised directly by the
+   white-box overflow test in tests/interpolate_overflow_test.c. */
+short interpolate(sonicStream stream, short* in, int oldSampleRate,
+                  int newSampleRate) {
+  /* Compute N-point sinc FIR-filter here.  Clip rather than overflow.
+     Accumulate in long: the sum of SINC_FILTER_POINTS taps can exceed int
+     range (each tap's product alone can approach INT_MAX, since a sinc
+     coefficient can be nearly twice SHRT_MAX in magnitude), and the
+     previous sign-flip overflow *detection* relied on signed overflow
+     having already happened, which is undefined behavior in C. long is
+     wide enough to hold the true sum without overflowing, so the result
+     can be clamped by comparing against real bounds instead. */
   int i;
-  int total = 0;
+  long total = 0;
   int position = stream->newRatePosition * oldSampleRate;
   int leftPosition = stream->oldRatePosition * newSampleRate;
   int rightPosition = (stream->oldRatePosition + 1) * newSampleRate;
   int ratio = rightPosition - position - 1;
   int width = rightPosition - leftPosition;
-  int weight, value;
-  int oldSign;
-  int overflowCount = 0;
+  int weight;
+  long value;
 
   for (i = 0; i < SINC_FILTER_POINTS; i++) {
     weight = findSincCoefficient(i, ratio, width);
-    value = in[i * stream->numChannels] * weight;
-    oldSign = getSign(total);
+    value = (long)in[i * stream->numChannels] * weight;
     total += value;
-    if (oldSign != getSign(total) && getSign(value) == oldSign) {
-      /* We must have overflowed.  This can happen with a sinc filter. */
-      overflowCount += oldSign;
-    }
   }
-  /* It is better to clip than to wrap if there was a overflow. */
-  if (overflowCount > 0) {
+  /* It is better to clip than to wrap if there was a overflow. Computed via
+     multiplication, not left-shift: SHRT_MIN is negative, and left-shifting
+     a negative value is undefined behavior. */
+  if (total > (long)SHRT_MAX * 65536L) {
     return SHRT_MAX;
-  } else if (overflowCount < 0) {
+  } else if (total < (long)SHRT_MIN * 65536L) {
     return SHRT_MIN;
   }
-  return total >> 16;
+  return (short)(total >> 16);
 }
 
 /* Change the rate.  Interpolate with a sinc FIR filter using a Hann window. */

--- a/tests/interpolate_overflow_test.c
+++ b/tests/interpolate_overflow_test.c
@@ -1,0 +1,59 @@
+/* Sonic library
+   Copyright 2026
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+#include "sonic.h"
+
+#include <limits.h>
+#include <stdio.h>
+
+#define SAMPLE_RATE 44100
+#define NUM_CHANNELS 1
+
+/* interpolate is not declared static in sonic.c specifically so this
+   white-box test can call it directly, without needing to drive the
+   public streaming API through the exact internal state (stream
+   position counters, sample-rate scaling) that reproducing this
+   deterministically would otherwise require. It is not part of the
+   public sonic.h contract. */
+short interpolate(sonicStream stream, short* in, int oldSampleRate,
+                  int newSampleRate);
+
+/* Verify interpolate's 12-tap sinc-filter accumulator clamps correctly
+   instead of relying on signed integer overflow to detect that it needs
+   to. On a freshly created stream, newRatePosition and oldRatePosition
+   are both 0, which makes interpolate's internal ratio/width depend only
+   on newSampleRate -- so choosing newSampleRate = 8000 gives a known,
+   reproducible weight at each of the 12 taps (only tap 5 has a large
+   coefficient; the filter is centered almost exactly on that tap for
+   this ratio). Setting in[] to the maximum-magnitude sample matching
+   each tap's coefficient sign guarantees the accumulator's true sum
+   exceeds INT_MAX -- this exact configuration was verified via UBSan
+   during development to trip a signed-integer-overflow at the old,
+   unfixed accumulation step, and to no longer do so after the fix,
+   while still returning the same, correctly clamped SHRT_MAX. */
+int sonicTestInterpolateOverflowClamping(void) {
+    sonicStream stream;
+    short in[12] = {32767, 32767, -32768, 32767, -32768, 32767,
+                     32767, -32768, 32767, 32767, 32767, 32767};
+    short result;
+
+    stream = sonicCreateStream(SAMPLE_RATE, NUM_CHANNELS);
+    if (stream == NULL) {
+        fprintf(stderr, "sonicCreateStream failed\n");
+        return 0;
+    }
+    result = interpolate(stream, in, SAMPLE_RATE, 8000);
+    sonicDestroyStream(stream);
+    if (result != SHRT_MAX) {
+        fprintf(stderr,
+                "interpolate should clamp this overflowing sum to SHRT_MAX, got %d\n",
+                result);
+        return 0;
+    }
+    return 1;
+}

--- a/tests/runtests.c
+++ b/tests/runtests.c
@@ -20,6 +20,7 @@ int main(int argc, char** argv) {
   assert(sonicTestParameters());
   assert(sonicTestFlush());
   assert(sonicTestSimpleProcessing());
+  assert(sonicTestInterpolateOverflowClamping());
   printf("All tests passed.\n");
   return 0;
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -17,6 +17,7 @@ int sonicTestStreamCreation(void);
 int sonicTestParameters(void);
 int sonicTestFlush(void);
 int sonicTestSimpleProcessing(void);
+int sonicTestInterpolateOverflowClamping(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes #66.

`interpolate()` accumulates 12 sinc-filter tap products into an `int total`, detecting overflow via a sign-flip heuristic (`oldSign != getSign(total)`) that itself relies on the signed overflow having already happened — undefined behavior in C, confirmed via a UBSan trace found while fuzzing: `signed integer overflow` at `sonic.c:956`.

Fix: accumulate in `long` instead (matching this file's existing convention — `insertPitchPeriod` already widens to `long` for the same reason), wide enough to hold the true sum without overflowing, so the final clamp compares against real bounds instead of inferring overflow from a sign flip. `getSign` had no other callers and is removed. The clamp bounds are computed via multiplication (`(long)SHRT_MIN * 65536L`), not left-shift — `SHRT_MIN` is negative, and left-shifting a negative value is undefined behavior, the same class of bug present elsewhere in this file (`findSincCoefficient`).

Adds `tests/interpolate_overflow_test.c` — a white-box test calling `interpolate()` directly (not `static`, for this reason). On a freshly created stream `newRatePosition`/`oldRatePosition` are both `0`, which makes the internal `ratio`/`width` depend only on `newSampleRate`, so each tap's weight is known in advance; setting each sample to the maximum magnitude matching its tap's coefficient sign guarantees the true sum exceeds `INT_MAX`. Verified via UBSan during development: trips the old code, doesn't trip the fixed code, and both return the same correctly-clamped `SHRT_MAX`.

**Deliberately not included**: `findSincCoefficient`'s separate left-shift bug sits on the exact same call path (`interpolate` calls it every invocation) but isn't fixed here, to keep this diff focused — it's fixed instead as a drive-by in the CI PR (#67), which needs it for the `strict-and-sanitized` job to pass `-Werror`+UBSan. Verified this fix is complete and correct in isolation by additionally patching that unrelated bug in a scratch copy and confirming the whole test suite is then completely clean under ASan+UBSan — once both this PR and #67 land, `master` will be fully clean.
