### PR TITLE
Fix NULL-stream crash and div-by-zero on malformed WAV channel count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,11 @@ check:
 test: sonic_unit_test
 	./sonic_unit_test
 
-sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
-	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/wave_channel_validation_test.c tests/genwave.c sonic.c sonic.h wave.c wave.h tests/tests.h tests/genwave.h
+	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/wave_channel_validation_test.c tests/genwave.c sonic.c wave.c -lm
 
 coverage:
-	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/wave_channel_validation_test.c tests/genwave.c sonic.c wave.c -lm
 	./sonic_coverage
 	gcov -o sonic_coverage-sonic.gcno sonic.c
 

--- a/main.c
+++ b/main.c
@@ -40,6 +40,14 @@ static void runSonic(char* inFileName, char* outFileName, float speed,
     }
   }
   stream = sonicCreateStream(sampleRate, numChannels);
+  if (stream == NULL) {
+    closeWaveFile(inFile);
+    if (outFile != NULL) {
+      closeWaveFile(outFile);
+    }
+    fprintf(stderr, "Unable to allocate a sonic stream\n");
+    exit(1);
+  }
   sonicSetSpeed(stream, speed);
   sonicSetPitch(stream, pitch);
   sonicSetRate(stream, rate);

--- a/tests/runtests.c
+++ b/tests/runtests.c
@@ -20,6 +20,7 @@ int main(int argc, char** argv) {
   assert(sonicTestParameters());
   assert(sonicTestFlush());
   assert(sonicTestSimpleProcessing());
+  assert(sonicTestWaveRejectsZeroChannels());
   printf("All tests passed.\n");
   return 0;
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -17,6 +17,7 @@ int sonicTestStreamCreation(void);
 int sonicTestParameters(void);
 int sonicTestFlush(void);
 int sonicTestSimpleProcessing(void);
+int sonicTestWaveRejectsZeroChannels(void);
 
 #ifdef __cplusplus
 }

--- a/tests/wave_channel_validation_test.c
+++ b/tests/wave_channel_validation_test.c
@@ -1,0 +1,57 @@
+/* Sonic library
+   Copyright 2026
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+#include "wave.h"
+
+#include <stdio.h>
+
+#define TEST_FILE_NAME "wave_channel_validation_test.wav"
+/* Byte offset of the numChannels field within the wave header written by
+   wave.c's writeHeader: 4 (RIFF) + 4 (size) + 4 (WAVE) + 4 (fmt ) + 4
+   (chunk size) + 2 (format) = 22. */
+#define NUM_CHANNELS_OFFSET 22
+
+/* Verify a wave file whose header claims 0 channels is rejected by
+   openInputWaveFile instead of being accepted with an unusable channel
+   count -- callers (e.g. the sonic CLI) divide by numChannels without
+   checking it, so letting 0 through causes a division by zero. Write a
+   normal, valid file via the public API, then corrupt just the
+   numChannels field on disk to simulate a malformed/adversarial input
+   file, since wave.h doesn't expose header construction directly. */
+int sonicTestWaveRejectsZeroChannels(void) {
+    waveFile file;
+    FILE* rawFile;
+    short zero = 0;
+    int sampleRate, numChannels;
+
+    file = openOutputWaveFile(TEST_FILE_NAME, 44100, 1);
+    if (file == NULL) {
+        fprintf(stderr, "openOutputWaveFile failed\n");
+        return 0;
+    }
+    closeWaveFile(file);
+
+    rawFile = fopen(TEST_FILE_NAME, "r+b");
+    if (rawFile == NULL) {
+        fprintf(stderr, "Unable to reopen %s for corruption\n", TEST_FILE_NAME);
+        return 0;
+    }
+    fseek(rawFile, NUM_CHANNELS_OFFSET, SEEK_SET);
+    fwrite(&zero, sizeof(short), 1, rawFile);
+    fclose(rawFile);
+
+    file = openInputWaveFile(TEST_FILE_NAME, &sampleRate, &numChannels);
+    remove(TEST_FILE_NAME);
+    if (file != NULL) {
+        fprintf(stderr,
+                "openInputWaveFile should reject a header with 0 channels\n");
+        closeWaveFile(file);
+        return 0;
+    }
+    return 1;
+}

--- a/wave.c
+++ b/wave.c
@@ -182,6 +182,10 @@ static int readHeader(waveFile file) {
   }
   file->numChannels =
       readShort(file); /* 22 - mono or stereo? 1 or 2?  (or 5 or ???) */
+  if (file->numChannels <= 0) {
+    fprintf(stderr, "Invalid number of channels: %d\n", file->numChannels);
+    return 0;
+  }
   file->sampleRate =
       readInt(file); /* 24 - samples per second (numbers per second) */
   readInt(file);     /* 28 - bytes per second */


### PR DESCRIPTION
Fixes 2 of the 3 crashes in #43. The third (`findPitchPeriodInRange`'s FPE) appears already resolved by 9456559 ("Clamp inputs to reasonable values") — see note at the bottom.

## 1. SEGV in `sonicSetSpeed`

`sonicCreateStream` is documented to "Return NULL only if we are out of memory," but `main.c`'s `runSonic` never checked before immediately calling `sonicSetSpeed(stream, ...)`, dereferencing a NULL stream.

Reproduced directly by forcing `sonicCreateStream` to return NULL (simulating the documented OOM path) in a scratch copy: SIGSEGV, write to offset `0x28` into the NULL struct — matches `stream->speed`'s field offset and the original report's crash address (`0x000000000028`) exactly.

Fix: check for NULL after `sonicCreateStream`, matching the existing `fprintf`+`exit(1)` pattern already used for the file-open failure checks right above it.

## 2. FPE in `runSonic` (main.c:55)

`BUFFER_SIZE / numChannels` divides by whatever `numChannels` `wave.c`'s `readHeader` read straight from the input file's header, with no validation — unlike the format and bit-depth fields, which are already rejected if invalid. A WAV file with `numChannels=0` in its `fmt` chunk passes `readHeader` unmodified, then `main.c`'s division raises SIGFPE.

Reproduced directly: a crafted 0-channel WAV file crashes the current CLI with SIGFPE (exit 136).

Fix: reject `numChannels <= 0` in `readHeader`, the same way the existing format/bit-depth checks already reject other invalid header fields.

Adds `tests/wave_channel_validation_test.c` — verified it fails (assertion failure, not a crash) against the pre-fix `wave.c` and passes after.

## Note on the third bug (FPE in `findPitchPeriodInRange`)

That crash traces to `*retMinDiff = minDiff / bestPeriod;` when `bestPeriod` stays `0` because the AMDF search loop's range (`minPeriod..maxPeriod`) is empty or inverted — which required an unclamped, degenerate `sampleRate` at the time the issue was filed (2023). 9456559 (Feb 2025) added the `sampleRate` clamp to `[SONIC_MIN_SAMPLE_RATE, SONIC_MAX_SAMPLE_RATE]` inside `sonicCreateStream`. I exhaustively checked every sample rate in that clamped range (and every value `findPitchPeriod`'s downsample/rescale step could produce) and found no case where the search range inverts anymore. No code change proposed for this one — flagging so #43 can be closed once this PR lands, rather than leaving a stale bug reference open.

## Test plan

- [x] `make test` — passes, new test included
- [x] `make CC=clang CFLAGS="-Wall -g -fsanitize=address,undefined -fno-omit-frame-pointer" test` — clean (only the separate, already-known `findSincCoefficient` left-shift finding, tracked in #67)
- [x] Built the real `sonic` CLI (plain `make`) and reproduced both fixes end-to-end against it directly (not just the unit tests), plus confirmed normal usage is unaffected