### PR TITLE
Fix SONAME to include the ABI version suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,14 @@ SHARED_OPT=-shared
 LIB_NAME=libsonic.so
 LIB_INTERNAL_NAME=libsonic_internal.so
 LIB_TAG=.0.3.0
+SONAME_SUFFIX=.0
 
 ifeq ($(UNAME), Darwin)
   SONAME=-install_name,$(LIBDIR)/
   SHARED_OPT=-dynamiclib
   LIB_NAME=libsonic.dylib
   LIB_TAG=
+  SONAME_SUFFIX=
 endif
 
 CFLAGS=-Wall -Wno-unused-function -g -ansi -fPIC -pthread
@@ -96,14 +98,14 @@ spectrogram.o: spectrogram.c sonic.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -DSONIC_SPECTROGRAM -c spectrogram.c
 
 $(LIB_NAME)$(LIB_TAG): $(EXTRA_OBJ) sonic.o wave.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $(SHARED_OPT) -Wl,$(SONAME)$(LIB_NAME) $(EXTRA_OBJ) sonic.o -o $(LIB_NAME)$(LIB_TAG) $(FFTLIB) wave.o
+	$(CC) $(CFLAGS) $(LDFLAGS) $(SHARED_OPT) -Wl,$(SONAME)$(LIB_NAME)$(SONAME_SUFFIX) $(EXTRA_OBJ) sonic.o -o $(LIB_NAME)$(LIB_TAG) $(FFTLIB) wave.o
 ifneq ($(UNAME), Darwin)
 	ln -sf $(LIB_NAME)$(LIB_TAG) $(LIB_NAME)
 	ln -sf $(LIB_NAME)$(LIB_TAG) $(LIB_NAME).0
 endif
 
 $(LIB_INTERNAL_NAME)$(LIB_TAG): $(EXTRA_OBJ) sonic_internal.o wave.o  # No spectrogram needed here.
-	$(CC) $(CFLAGS) $(LDFLAGS) $(SHARED_OPT) -Wl,$(SONAME)$(LIB_INTERNAL_NAME) $(EXTRA_OBJ) sonic_internal.o -o $(LIB_INTERNAL_NAME)$(LIB_TAG) $(FFTLIB)  wave.o
+	$(CC) $(CFLAGS) $(LDFLAGS) $(SHARED_OPT) -Wl,$(SONAME)$(LIB_INTERNAL_NAME)$(SONAME_SUFFIX) $(EXTRA_OBJ) sonic_internal.o -o $(LIB_INTERNAL_NAME)$(LIB_TAG) $(FFTLIB)  wave.o
 ifneq ($(UNAME), Darwin)
 	ln -sf $(LIB_INTERNAL_NAME)$(LIB_TAG) $(LIB_INTERNAL_NAME)
 	ln -sf $(LIB_INTERNAL_NAME)$(LIB_TAG) $(LIB_INTERNAL_NAME).0


### PR DESCRIPTION
The shared library's embedded SONAME was passed as `-Wl,$(SONAME)$(LIB_NAME)` — e.g. plain `libsonic.so` — while the file actually built and installed is `libsonic.so.0.3.0`, with `libsonic.so.0` as the versioned runtime symlink pointing at it. A correct SONAME must match that runtime symlink (`libsonic.so.0`), not the unversioned dev symlink (`libsonic.so`) used only at link time — a mismatched SONAME breaks the usual shared-library upgrade path, since the dynamic linker embeds and looks up the SONAME, not the on-disk filename.

Same bug as [espeak-ng/sonic#1](https://github.com/espeak-ng/sonic/issues/1); this repo's Makefile has the identical unqualified `-Wl,$(SONAME)$(LIB_NAME)` lines (that repo forked from here and never touched this section), so I'm fixing it here too even though no issue was filed against this repo directly.

Verified with `readelf -d` before/after: SONAME went from `libsonic.so` to `libsonic.so.0` for both `libsonic.so` and `libsonic_internal.so`.

Adds `SONAME_SUFFIX` (`.0`, following the `LIB_TAG` platform-conditional pattern already in this file) rather than changing `LIB_NAME` itself, since `LIB_NAME` is also used unversioned elsewhere (the dev symlink, install rules). Empty on Darwin, where `SONAME` is actually an `install_name` that already matches the unversioned `libsonic.dylib` file this Makefile builds there (`LIB_TAG` is empty on Darwin too) — so Darwin's behavior is unchanged.

## Test plan

- [x] `readelf -d libsonic.so.0.3.0 | grep -i soname` — now `libsonic.so.0` (was `libsonic.so`)
- [x] `readelf -d libsonic_internal.so.0.3.0 | grep -i soname` — now `libsonic_internal.so.0`
- [x] Full `make` — succeeds, symlinks (`libsonic.so`, `libsonic.so.0` → `libsonic.so.0.3.0`) unchanged
- [x] `make test` — passes