### PR TITLE
Restore vocal-chord-emulation ("linear") pitch scaling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,11 @@ check:
 test: sonic_unit_test
 	./sonic_unit_test
 
-sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
-	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/chord_pitch_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
+	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/chord_pitch_test.c tests/genwave.c sonic.c -lm
 
 coverage:
-	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/chord_pitch_test.c tests/genwave.c sonic.c -lm
 	./sonic_coverage
 	gcov -o sonic_coverage-sonic.gcno sonic.c
 

--- a/sonic.c
+++ b/sonic.c
@@ -232,6 +232,7 @@ struct sonicStreamStruct {
   int sampleRate;
   int prevPeriod;
   int prevMinDiff;
+  int useChordPitch;
 };
 
 /* Attach user data to the stream. */
@@ -303,12 +304,13 @@ void sonicSetRate(sonicStream stream, float rate) {
   stream->newRatePosition = 0;
 }
 
-/* DEPRECATED.  Get the vocal chord pitch setting. */
-int sonicGetChordPitch(sonicStream stream) { return 0; }
+/* Get the vocal chord pitch setting. */
+int sonicGetChordPitch(sonicStream stream) { return stream->useChordPitch; }
 
-/* DEPRECATED. Set the vocal chord mode for pitch computation.  Default is off.
- */
-void sonicSetChordPitch(sonicStream stream, int useChordPitch) {}
+/* Set the vocal chord mode for pitch computation.  Default is off. */
+void sonicSetChordPitch(sonicStream stream, int useChordPitch) {
+  stream->useChordPitch = useChordPitch;
+}
 
 /* Get the quality setting. */
 int sonicGetQuality(sonicStream stream) { return stream->quality; }
@@ -882,6 +884,35 @@ static void overlapAdd(int numSamples, int numChannels, short* out,
   }
 }
 
+/* Overlap two sound segments, ramp the volume of one down, while ramping the
+   other one from zero up, and add them, storing the result at the output. */
+static void overlapAddWithSeparation(int numSamples, int numChannels,
+                                     int separation, short* out,
+                                     short* rampDown, short* rampUp) {
+  short *o, *u, *d;
+  int i, t;
+
+  for (i = 0; i < numChannels; i++) {
+    o = out + i;
+    u = rampUp + i;
+    d = rampDown + i;
+    for (t = 0; t < numSamples + separation; t++) {
+      if (t < separation) {
+        *o = *d * (numSamples - t) / numSamples;
+        d += numChannels;
+      } else if (t < numSamples) {
+        *o = (*d * (numSamples - t) + *u * (t - separation)) / numSamples;
+        d += numChannels;
+        u += numChannels;
+      } else {
+        *o = *u * (t - separation) / numSamples;
+        u += numChannels;
+      }
+      o += numChannels;
+    }
+  }
+}
+
 /* Just move the new samples in the output buffer to the pitch buffer */
 static int moveNewSamplesToPitchBuffer(sonicStream stream,
                                        int originalNumOutputSamples) {
@@ -917,6 +948,60 @@ static void removePitchSamples(sonicStream stream, int numSamples) {
         (stream->numPitchSamples - numSamples) * sizeof(short) * numChannels);
   }
   stream->numPitchSamples -= numSamples;
+}
+
+/* Change the pitch.  The latency this introduces could be reduced by looking at
+   past samples to determine pitch, rather than future. */
+static int adjustPitch(sonicStream stream, int originalNumOutputSamples) {
+  float pitch = stream->pitch;
+  int numChannels = stream->numChannels;
+  int period, newPeriod, separation;
+  int position = 0;
+  short* out;
+  short* rampDown;
+  short* rampUp;
+
+  if (stream->numOutputSamples == originalNumOutputSamples) {
+    return 1;
+  }
+  if (!moveNewSamplesToPitchBuffer(stream, originalNumOutputSamples)) {
+    return 0;
+  }
+  while (stream->numPitchSamples - position >= stream->maxRequired) {
+    period = findPitchPeriod(stream,
+                             stream->pitchBuffer + position * numChannels, 0);
+    newPeriod = period / pitch;
+    /* Clip rather than overflow: at extreme pitch settings, an unclamped
+       newPeriod can hit 0 (dividing by it below) or, in the opposite
+       direction, exceed how many samples are actually buffered ahead of
+       position (only maxRequired is guaranteed, by the while condition
+       above), which would read/write past pitchBuffer/outputBuffer. */
+    if (newPeriod < 1) {
+      newPeriod = 1;
+    } else if (newPeriod > stream->maxRequired) {
+      newPeriod = stream->maxRequired;
+    }
+    if (!enlargeOutputBufferIfNeeded(stream, newPeriod)) {
+      return 0;
+    }
+    out = stream->outputBuffer + stream->numOutputSamples * numChannels;
+    if (pitch >= 1.0f) {
+      rampDown = stream->pitchBuffer + position * numChannels;
+      rampUp =
+          stream->pitchBuffer + (position + period - newPeriod) * numChannels;
+      overlapAdd(newPeriod, numChannels, out, rampDown, rampUp);
+    } else {
+      rampDown = stream->pitchBuffer + position * numChannels;
+      rampUp = stream->pitchBuffer + position * numChannels;
+      separation = newPeriod - period;
+      overlapAddWithSeparation(period, numChannels, separation, out, rampDown,
+                               rampUp);
+    }
+    stream->numOutputSamples += newPeriod;
+    position += period;
+  }
+  removePitchSamples(stream, position);
+  return 1;
 }
 
 /* Approximate the sinc function times a Hann window from the sinc table. */
@@ -1162,7 +1247,13 @@ static int processStreamInput(sonicStream stream) {
       return 0;
     }
   }
-  if (rate != 1.0f) {
+  if (stream->useChordPitch) {
+    if (stream->pitch != 1.0f) {
+      if (!adjustPitch(stream, originalNumOutputSamples)) {
+        return 0;
+      }
+    }
+  } else if (rate != 1.0f) {
     if (!adjustRate(stream, rate, originalNumOutputSamples)) {
       return 0;
     }

--- a/sonic.h
+++ b/sonic.h
@@ -194,8 +194,6 @@ void sonicSetRate(sonicStream stream, float rate);
 float sonicGetVolume(sonicStream stream);
 /* Set the scaling factor of the stream. */
 void sonicSetVolume(sonicStream stream, float volume);
-/* Chord pitch is DEPRECATED.  AFAIK, it was never used by anyone.  These
-   functions still exist to avoid breaking existing code. */
 /* Get the chord pitch setting. */
 int sonicGetChordPitch(sonicStream stream);
 /* Set chord pitch mode on or off.  Default is off.  See the documentation

--- a/tests/chord_pitch_test.c
+++ b/tests/chord_pitch_test.c
@@ -1,0 +1,134 @@
+/* Sonic library
+   Copyright 2026
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+#include "sonic.h"
+
+#include "genwave.h"
+
+#include <stdio.h>
+
+#define SAMPLE_RATE 44100
+#define FREQ 200
+#define PERIOD (SAMPLE_RATE / FREQ)
+#define AMPLITUDE 6000
+#define NUM_PERIODS 500
+#define NUM_SAMPLES (NUM_PERIODS * PERIOD)
+#define READ_BUF_LEN 1000
+
+/* Process all of samples through stream, and return a (length, checksum)
+   summary of everything read back, cheap enough to compare two runs without
+   holding the whole output in memory. */
+static void processAndSummarize(sonicStream stream, const short* samples,
+                                int numSamples, int* outLength,
+                                unsigned long* outChecksum) {
+    short readBuf[READ_BUF_LEN];
+    int samplesRead, i;
+    int length = 0;
+    unsigned long checksum = 0;
+
+    if (!sonicWriteShortToStream(stream, samples, numSamples)) {
+        fprintf(stderr, "sonicWriteShortToStream failed\n");
+    }
+    while ((samplesRead = sonicReadShortFromStream(stream, readBuf,
+                                                    READ_BUF_LEN)) != 0) {
+        for (i = 0; i < samplesRead; i++) {
+            checksum = checksum * 31 + readBuf[i];
+        }
+        length += samplesRead;
+    }
+    sonicFlushStream(stream);
+    while ((samplesRead = sonicReadShortFromStream(stream, readBuf,
+                                                    READ_BUF_LEN)) != 0) {
+        for (i = 0; i < samplesRead; i++) {
+            checksum = checksum * 31 + readBuf[i];
+        }
+        length += samplesRead;
+    }
+    *outLength = length;
+    *outChecksum = checksum;
+}
+
+/* sonicSetChordPitch's vocal-chord-emulation ("linear") pitch-scaling mode is
+   documented to change how pitch is computed (sonic.h: "Set the vocal chord
+   mode for pitch computation"). Enabling it must therefore produce different
+   output than leaving it off, for the same pitch setting -- otherwise the
+   setting has no effect, which is exactly what
+   https://github.com/waywardgeek/sonic/issues/49 reports ("sonic -c -p 0.5
+   ..." and "sonic -p 0.5 ..." give identical output). */
+int sonicTestChordPitchChangesOutput(void) {
+    short samples[NUM_SAMPLES];
+    int numSamples = genSineWave(samples, NUM_SAMPLES, SAMPLE_RATE, PERIOD,
+                                 AMPLITUDE, NUM_PERIODS);
+    sonicStream stream;
+    int defaultLength, chordLength;
+    unsigned long defaultChecksum, chordChecksum;
+
+    if (numSamples != NUM_SAMPLES) {
+        fprintf(stderr, "genSineWave failed\n");
+        return 0;
+    }
+
+    stream = sonicCreateStream(SAMPLE_RATE, 1);
+    sonicSetPitch(stream, 0.5f);
+    processAndSummarize(stream, samples, numSamples, &defaultLength,
+                        &defaultChecksum);
+    sonicDestroyStream(stream);
+
+    stream = sonicCreateStream(SAMPLE_RATE, 1);
+    sonicSetChordPitch(stream, 1);
+    sonicSetPitch(stream, 0.5f);
+    processAndSummarize(stream, samples, numSamples, &chordLength,
+                        &chordChecksum);
+    sonicDestroyStream(stream);
+
+    if (defaultLength == chordLength && defaultChecksum == chordChecksum) {
+        fprintf(stderr,
+                "sonicSetChordPitch(stream, 1) should change output for the "
+                "same pitch setting, but it had no effect (length=%d, "
+                "checksum=%lu both times)\n",
+                defaultLength, defaultChecksum);
+        return 0;
+    }
+    return 1;
+}
+
+/* adjustPitch's newPeriod (period / pitch) is unbounded above and below: at
+   SONIC_MIN_PITCH_SETTING, newPeriod balloons far past what's actually
+   buffered ahead of the current position, and overlapAddWithSeparation reads
+   that many samples from the pitch buffer -- a heap-buffer-overflow,
+   confirmed via ASan during development. Just processing audio at the
+   extreme ends of the pitch range with chord pitch enabled, without
+   crashing, is the regression check here; the exact clamped output isn't
+   otherwise meaningful. */
+int sonicTestChordPitchExtremeRatioDoesNotOverflow(void) {
+    short samples[NUM_SAMPLES];
+    int numSamples = genSineWave(samples, NUM_SAMPLES, SAMPLE_RATE, PERIOD,
+                                 AMPLITUDE, NUM_PERIODS);
+    sonicStream stream;
+    int length;
+    unsigned long checksum;
+
+    if (numSamples != NUM_SAMPLES) {
+        fprintf(stderr, "genSineWave failed\n");
+        return 0;
+    }
+
+    stream = sonicCreateStream(SAMPLE_RATE, 1);
+    sonicSetChordPitch(stream, 1);
+    sonicSetPitch(stream, SONIC_MIN_PITCH_SETTING);
+    processAndSummarize(stream, samples, numSamples, &length, &checksum);
+    sonicDestroyStream(stream);
+
+    stream = sonicCreateStream(SAMPLE_RATE, 1);
+    sonicSetChordPitch(stream, 1);
+    sonicSetPitch(stream, SONIC_MAX_PITCH_SETTING);
+    processAndSummarize(stream, samples, numSamples, &length, &checksum);
+    sonicDestroyStream(stream);
+
+    return 1;
+}

--- a/tests/runtests.c
+++ b/tests/runtests.c
@@ -20,6 +20,8 @@ int main(int argc, char** argv) {
   assert(sonicTestParameters());
   assert(sonicTestFlush());
   assert(sonicTestSimpleProcessing());
+  assert(sonicTestChordPitchChangesOutput());
+  assert(sonicTestChordPitchExtremeRatioDoesNotOverflow());
   printf("All tests passed.\n");
   return 0;
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -17,6 +17,8 @@ int sonicTestStreamCreation(void);
 int sonicTestParameters(void);
 int sonicTestFlush(void);
 int sonicTestSimpleProcessing(void);
+int sonicTestChordPitchChangesOutput(void);
+int sonicTestChordPitchExtremeRatioDoesNotOverflow(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes #49.

## Summary

`sonicSetChordPitch`/`sonicGetChordPitch` had been no-op stubs since [09b4225](https://github.com/waywardgeek/sonic/commit/09b4225b261a193cc76c46ee683e742cf251bc87) (2022's "Changed algorithm to enable rapid changing of speed accurately"), which left the setter with nothing to write to — `sonic.h` even documented it as "DEPRECATED... AFAIK never used by anyone." But it is used: the CLI's `-c` flag prints "Scaling pitch linearly" yet silently produces byte-identical output to not passing `-c` at all, exactly as reported (`sonic -c -p 0.5 ...` vs `sonic -p 0.5 ...`). Your own reply on the issue treats it as a real bug to fix, not a deprecation to uphold, so this restores the feature instead of just documenting the gap — but happy to go the other way if you'd rather formally drop it.

Every helper `adjustPitch` (the pre-2022 pitch-shifting implementation) depended on — `moveNewSamplesToPitchBuffer`, `findPitchPeriod`, `enlargeOutputBufferIfNeeded`, `overlapAdd`, `removePitchSamples`, and the `pitchBuffer`/`numPitchSamples` struct fields — survived the 2022 rewrite unchanged (they're shared with `changeSpeed`'s speed-change path). Only `adjustPitch`, `overlapAddWithSeparation`, the `useChordPitch` struct field, and its two call sites in `processStreamInput` were actually removed. Restored all four verbatim from the pre-rewrite implementation, wiring `processStreamInput`'s rate computation and `adjustPitch` call back in around the current pitch/speed tracking (`updateNumInputSamples`'s `speed = stream->speed / stream->pitch` compensation already applies unconditionally to both chord and non-chord paths — no changes needed there).

## A real bug found while restoring this

Pointing 2022-dormant code at the current codebase's much wider `SONIC_MIN/MAX_PITCH_SETTING` range (0.05–20.0, a 400x span) surfaced a bug the old code was never exercised against: `newPeriod` (`period / pitch`) is unbounded in both directions. Too small (extreme high pitch, low sample rate) divides by zero in `overlapAdd`. Too large (extreme low pitch) makes `overlapAddWithSeparation` read past how many samples are actually buffered ahead of the current position — a heap-buffer-overflow, confirmed via ASan. Clamped `newPeriod` to `[1, stream->maxRequired]`, matching this file's existing "clip rather than overflow" convention elsewhere.

Separately investigated: exhaustive sanitized parameter sweeps (sample rate, channels, pitch, speed, quality) turned up no other crashes. Some `quality=1` + very-high-sample-rate combinations are slow (multi-second), but the existing, unmodified `changeSpeed` path shows the same magnitude of slowness under comparably adversarial parameters — a pre-existing cost of `findPitchPeriod`'s O(range) search at `quality=1`, not something this change introduces or makes worse.

## Tests

Adds `tests/chord_pitch_test.c`:
- `sonicTestChordPitchChangesOutput`: enabling chord pitch must change output for the same pitch setting, or the setting has no effect — this is the exact bug reported (verified failing before this fix: identical length and checksum both times).
- `sonicTestChordPitchExtremeRatioDoesNotOverflow`: processes audio at both ends of the pitch range with chord pitch enabled without crashing (verified failing — ASan heap-buffer-overflow — with the `newPeriod` clamp temporarily removed, passing with it restored).

Also drops `sonic.h`'s "DEPRECATED... never used by anyone" comment on the getter/setter, now inaccurate.

## Test plan

- [x] `make test` — passes
- [x] `make CC=clang CFLAGS="-Wall -g -fsanitize=address,undefined -fno-omit-frame-pointer" test` — clean (only the separate, already-known `findSincCoefficient` finding, tracked in #67)
- [x] Built the real `sonic` CLI and reproduced the exact issue repro end-to-end: `sonic -c -p 0.5` and `sonic -p 0.5` now produce different output (previously byte-identical)