### PR TITLE
Add sonic_api_test.c to tests/Makefile's TEST_SRC

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,8 @@ CFLAGS=-Wall -Wno-unused-function -g -ansi -fPIC -pthread -I ..
 #CFLAGS += -Wall -Wno-unused-function -ansi -fPIC -pthread -I ..
 
 TEST_SRC = \
-input_clamping_test.c
+input_clamping_test.c \
+sonic_api_test.c
 
 CC=gcc
 


### PR DESCRIPTION
## Summary

`tests.h`/`runtests.c` declare and call `sonicTestStreamCreation`, `sonicTestParameters`, `sonicTestFlush`, and `sonicTestSimpleProcessing` — all defined in `tests/sonic_api_test.c` — but `tests/Makefile`'s `TEST_SRC` was never updated to include it, so `cd tests && make runtests` fails to link with undefined references to all four.

Reproduced on a clean checkout of `master`:
\`\`\`
$ cd tests && make runtests
...
undefined reference to `sonicTestStreamCreation'
undefined reference to `sonicTestParameters'
undefined reference to `sonicTestFlush'
undefined reference to `sonicTestSimpleProcessing'
\`\`\`

(The root `Makefile`'s own `sonic_unit_test` target already includes `tests/sonic_api_test.c` correctly — this is specifically about `tests/Makefile`'s separate, standalone target.)

## Test plan

- [x] `cd tests && make runtests && ./runtests` — now builds and passes (was a link failure before)