### PR TITLE
Fix rate-position desync from repeated sonicSetPitch calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,11 @@ check:
 test: sonic_unit_test
 	./sonic_unit_test
 
-sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
-	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/pitch_position_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
+	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/pitch_position_test.c tests/genwave.c sonic.c -lm
 
 coverage:
-	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/pitch_position_test.c tests/genwave.c sonic.c -lm
 	./sonic_coverage
 	gcov -o sonic_coverage-sonic.gcno sonic.c
 

--- a/sonic.c
+++ b/sonic.c
@@ -289,6 +289,9 @@ float sonicGetPitch(sonicStream stream) { return stream->pitch; }
 /* Set the pitch of the stream. */
 void sonicSetPitch(sonicStream stream, float pitch) {
   stream->pitch = CLAMP(pitch, SONIC_MIN_PITCH_SETTING, SONIC_MAX_PITCH_SETTING);
+
+  stream->oldRatePosition = 0;
+  stream->newRatePosition = 0;
 }
 
 /* Get the rate of the stream. */

--- a/tests/pitch_position_test.c
+++ b/tests/pitch_position_test.c
@@ -1,0 +1,65 @@
+/* Sonic library
+   Copyright 2026
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+#include "sonic.h"
+
+#include "genwave.h"
+
+#include <stdio.h>
+
+#define SAMPLE_RATE 96000
+#define FREQ 200
+#define PERIOD (SAMPLE_RATE / FREQ)
+#define AMPLITUDE 6000
+#define CHUNK_PERIODS 3
+#define CHUNK_SAMPLES (CHUNK_PERIODS * PERIOD)
+#define READ_BUF_LEN 4096
+
+/* sonicSetRate resets oldRatePosition/newRatePosition to 0 (see its
+   definition just above sonicSetPitch), because adjustRate's wraparound
+   arithmetic assumes those two counters were accumulated under a single,
+   consistent (oldSampleRate, newSampleRate) ratio -- one that changing the
+   rate mid-stream immediately invalidates. processStreamInput folds pitch
+   into that same ratio (rate = stream->rate * stream->pitch), so
+   sonicSetPitch invalidates the ratio exactly the same way, but it doesn't
+   reset the counters. Left to drift across enough pitch changes, the
+   counters grow large enough to integer-overflow interpolate()'s position
+   arithmetic, indexing sincTable wildly out of bounds -- confirmed via
+   ASan (global-buffer-overflow in findSincCoefficient) and a native crash
+   without it. This specific pitch sequence and sample rate were found by
+   sweeping random pitch changes for a case that crashes reliably and then
+   trimmed to the smallest deterministic repro. */
+int sonicTestRepeatedPitchChangesDontDesyncRatePosition(void) {
+    short chunk[CHUNK_SAMPLES];
+    sonicStream stream;
+    short readBuf[READ_BUF_LEN];
+    float pitches[] = {2.5f, 0.4f, 3.1f, 0.6f, 4.0f, 0.3f, 2.0f, 0.5f, 3.5f, 0.45f};
+    int i, n = sizeof(pitches) / sizeof(pitches[0]);
+    int actualSamples;
+
+    stream = sonicCreateStream(SAMPLE_RATE, 1);
+    if (stream == NULL) {
+        fprintf(stderr, "sonicCreateStream failed\n");
+        return 0;
+    }
+    for (i = 0; i < n; i++) {
+        actualSamples = genSineWave(chunk, CHUNK_SAMPLES, SAMPLE_RATE, PERIOD,
+                                    AMPLITUDE, CHUNK_PERIODS);
+        sonicSetPitch(stream, pitches[i]);
+        if (!sonicWriteShortToStream(stream, chunk, actualSamples)) {
+            fprintf(stderr, "sonicWriteShortToStream failed\n");
+            sonicDestroyStream(stream);
+            return 0;
+        }
+        while (sonicReadShortFromStream(stream, readBuf, READ_BUF_LEN) != 0);
+    }
+    sonicFlushStream(stream);
+    while (sonicReadShortFromStream(stream, readBuf, READ_BUF_LEN) != 0);
+    sonicDestroyStream(stream);
+    return 1;
+}

--- a/tests/runtests.c
+++ b/tests/runtests.c
@@ -20,6 +20,7 @@ int main(int argc, char** argv) {
   assert(sonicTestParameters());
   assert(sonicTestFlush());
   assert(sonicTestSimpleProcessing());
+  assert(sonicTestRepeatedPitchChangesDontDesyncRatePosition());
   printf("All tests passed.\n");
   return 0;
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -17,6 +17,7 @@ int sonicTestStreamCreation(void);
 int sonicTestParameters(void);
 int sonicTestFlush(void);
 int sonicTestSimpleProcessing(void);
+int sonicTestRepeatedPitchChangesDontDesyncRatePosition(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes #41, fixes #39.

## Summary

Both issues report a crash/hang after several `sonicSetPitch` calls on a live stream. #41's original report includes `Assertion failed: stream->newRatePosition != newSampleRate` — a manual (`fprintf`+`exit`) invariant check that existed until it was quietly dropped in `a1746b3` (2021-10-13) — over a year before either issue was filed, meaning both reporters were on stale/vendored builds predating that removal and the literal crash text can't reproduce on any current code. Removing the check didn't fix the underlying bug, just stopped it from failing loudly.

`adjustRate`'s wraparound arithmetic (`oldRatePosition`/`newRatePosition`) assumes both counters were accumulated under one consistent `(oldSampleRate, newSampleRate)` ratio — `processStreamInput` computes that ratio as `stream->rate * stream->pitch`. `sonicSetRate` resets both counters to 0 because changing rate invalidates the ratio the counters were accumulated under; `sonicSetPitch` changes the exact same ratio but never got the same reset.

Left to run, the counters drift further from what the (now-changed) ratio expects with every subsequent pitch change. Confirmed via a targeted random sweep (sample rate × channels × many pitch/rate/speed changes) that the invariant genuinely gets violated on current code, not just hypothetically — and traced one violating case all the way to a real crash: the drifted counters eventually overflow `interpolate()`'s position arithmetic, indexing `sincTable` far out of bounds (confirmed via ASan: global-buffer-overflow in `findSincCoefficient`, called from `interpolate`, called from `adjustRate`).

## Fix

Reset `oldRatePosition`/`newRatePosition` in `sonicSetPitch` too, mirroring `sonicSetRate` exactly (a two-line diff).

## Tests

Adds `tests/pitch_position_test.c` with a deterministic repro (10 fixed pitch values, no randomness) trimmed down from the random sweep that found it — verified crashing under ASan before this fix, clean after.

## Test plan

- [x] `make test` — passes
- [x] `make CC=clang CFLAGS="-Wall -g -fsanitize=address,undefined -fno-omit-frame-pointer" test` — clean (only the separate, already-known `findSincCoefficient` finding, tracked in #67)
- [x] Re-ran the full random sweep (sample rate × channels × 30 pitch/rate/speed changes × 10 seeds = 140 runs) against the fixed code under ASan+UBSan — zero failures, was failing consistently before the fix