### PR TITLE
Fix sonicFlushStream understating duration at low speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,11 @@ check:
 test: sonic_unit_test
 	./sonic_unit_test
 
-sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
-	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+sonic_unit_test: tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/slowdown_flush_test.c tests/genwave.c sonic.c sonic.h tests/tests.h tests/genwave.h
+	$(CC) $(CFLAGS) -I. -o sonic_unit_test tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/slowdown_flush_test.c tests/genwave.c sonic.c -lm
 
 coverage:
-	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/genwave.c sonic.c -lm
+	$(CC) $(CFLAGS) -I. -fprofile-arcs -ftest-coverage -o sonic_coverage tests/runtests.c tests/sonic_api_test.c tests/input_clamping_test.c tests/slowdown_flush_test.c tests/genwave.c sonic.c -lm
 	./sonic_coverage
 	gcov -o sonic_coverage-sonic.gcno sonic.c
 

--- a/sonic.c
+++ b/sonic.c
@@ -702,6 +702,13 @@ int sonicFlushStream(sonicStream stream) {
   memset(stream->inputBuffer + remainingSamples * stream->numChannels, 0,
          2 * maxRequired * sizeof(short) * stream->numChannels);
   stream->numInputSamples += 2 * maxRequired;
+  /* Keep inputPlayTime in step with numInputSamples, matching how a real
+     write of this many samples would have updated it (see
+     updateNumInputSamples). Otherwise processStreamInput's localSpeed --
+     numInputSamples * samplePeriod / inputPlayTime -- comes out higher
+     than the caller's requested speed for the rest of this flush, since
+     the numerator just grew but the denominator didn't. */
+  stream->inputPlayTime += 2 * maxRequired * stream->samplePeriod / speed;
   if (!sonicWriteShortToStream(stream, NULL, 0)) {
     return 0;
   }

--- a/tests/runtests.c
+++ b/tests/runtests.c
@@ -20,6 +20,7 @@ int main(int argc, char** argv) {
   assert(sonicTestParameters());
   assert(sonicTestFlush());
   assert(sonicTestSimpleProcessing());
+  assert(sonicTestSlowdownFlushProducesExpectedDuration());
   printf("All tests passed.\n");
   return 0;
 }

--- a/tests/slowdown_flush_test.c
+++ b/tests/slowdown_flush_test.c
@@ -1,0 +1,89 @@
+/* Sonic library
+   Copyright 2026
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+#include "sonic.h"
+
+#include "genwave.h"
+
+#include <stdio.h>
+
+#define SAMPLE_RATE 44100
+#define FREQ 180
+#define PERIOD (SAMPLE_RATE / FREQ)
+#define AMPLITUDE 6000
+#define NUM_PERIODS 10
+#define NUM_SAMPLES (NUM_PERIODS * PERIOD)
+#define SPEED 0.060000002f
+#define READ_BUF_LEN 100000
+
+/* https://github.com/waywardgeek/sonic/issues/38: a short sample slowed
+   down heavily (speed <= 0.5, the insertPitchPeriod path) came out both
+   too short overall and padded with a large block of trailing silence.
+
+   sonicFlushStream appends 2*maxRequired samples of silence directly to
+   numInputSamples (to give the pitch-period algorithms enough lookahead
+   to drain what's buffered) but never advances inputPlayTime to match.
+   processStreamInput computes its actual working speed as
+   numInputSamples * samplePeriod / inputPlayTime -- so once flush's
+   padding inflates numInputSamples without inputPlayTime keeping pace,
+   that computed speed comes out much higher than the caller's requested
+   speed, and insertPitchPeriod stretches the remaining audio by far less
+   than it should. The last chunk of real audio and the trailing silence
+   both get compressed into a much shorter span than expected, and
+   whatever's left over reads back as silence. */
+int sonicTestSlowdownFlushProducesExpectedDuration(void) {
+    short samples[NUM_SAMPLES];
+    int numSamples = genSineWave(samples, NUM_SAMPLES, SAMPLE_RATE, PERIOD,
+                                 AMPLITUDE, NUM_PERIODS);
+    sonicStream stream;
+    short output[READ_BUF_LEN];
+    int total = 0, samplesRead, nonzeroEnd;
+    double expected;
+
+    if (numSamples != NUM_SAMPLES) {
+        fprintf(stderr, "genSineWave failed\n");
+        return 0;
+    }
+    stream = sonicCreateStream(SAMPLE_RATE, 1);
+    if (stream == NULL) {
+        fprintf(stderr, "sonicCreateStream failed\n");
+        return 0;
+    }
+    sonicSetSpeed(stream, SPEED);
+    if (!sonicWriteShortToStream(stream, samples, numSamples)) {
+        fprintf(stderr, "sonicWriteShortToStream failed\n");
+        sonicDestroyStream(stream);
+        return 0;
+    }
+    sonicFlushStream(stream);
+    while ((samplesRead = sonicReadShortFromStream(stream, output,
+                                                    READ_BUF_LEN)) != 0) {
+        total += samplesRead;
+    }
+    sonicDestroyStream(stream);
+
+    expected = numSamples / (double)SPEED;
+    if (total < 0.9 * expected || total > 1.1 * expected) {
+        fprintf(stderr,
+                "expected total output near %f samples, got %d\n",
+                expected, total);
+        return 0;
+    }
+
+    nonzeroEnd = total;
+    while (nonzeroEnd > 0 && output[nonzeroEnd - 1] == 0) {
+        nonzeroEnd--;
+    }
+    if (total - nonzeroEnd > 0.05 * total) {
+        fprintf(stderr,
+                "trailing silence too large: %d of %d output samples (%.1f%%)\n",
+                total - nonzeroEnd, total, 100.0 * (total - nonzeroEnd) / total);
+        return 0;
+    }
+    return 1;
+}

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -17,6 +17,7 @@ int sonicTestStreamCreation(void);
 int sonicTestParameters(void);
 int sonicTestFlush(void);
 int sonicTestSimpleProcessing(void);
+int sonicTestSlowdownFlushProducesExpectedDuration(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes #38, fixes #40.

## Summary

A short sample slowed down heavily (speed ≤ 0.5) came out both too short overall and padded with a large block of trailing silence — confirmed with the reporter's own numbers (0.053s input, speed 0.06) reproduced almost exactly: 0.732s total output, 0.169s of it (23%) trailing silence, versus an expected ~0.883s.

`sonicFlushStream` appends `2*maxRequired` samples of silence directly to `stream->numInputSamples` (giving the pitch-period algorithms enough lookahead to drain whatever's still buffered) but never advances `stream->inputPlayTime` to match. `processStreamInput` computes its actual working speed for `insertPitchPeriod` as `numInputSamples * samplePeriod / inputPlayTime` — so once the padding inflates `numInputSamples` without `inputPlayTime` keeping pace, that computed speed comes out well above the caller's requested speed for the rest of the flush.

Traced this precisely with the reporter's own numbers: requested speed `0.06`, but the flush-triggered call computed `0.18` — 3x too fast, which is why the tail of real audio (and the silence padding after it) gets compressed into a far shorter span than it should, and whatever's left over reads back as silence.

## Fix

Advance `inputPlayTime` by the same formula `updateNumInputSamples` already uses for real writes (`numSamples * samplePeriod / speed`) when appending the flush padding, so the computed speed stays correct through the whole flush. A one-line addition.

## Also fixes #40

#40 (`slowing down and introducing abnormal audio` at `-s 0.8`) is the same root cause at a less extreme speed — confirmed directly: unfixed code produces 568 trailing zero samples (2.1%) and a truncated tail at speed 0.8; this fix produces a clean, correctly-decaying tail and 0 trailing zeros, with output landing exactly on the expected duration.

## Verification

With the reporter's own numbers: output duration goes from 0.732s (32295 samples, 23% trailing silence) to 0.898s (39608 samples, matching `sonicFlushStream`'s own `expectedOutputSamples` calculation exactly), trailing silence down to under 0.2% (a normal, tiny overlap-add tail).

Swept 6 sample rates × 16 speeds (0.05x–20x) to confirm the fix generalizes: no case has more than 4.4% trailing silence (was up to 23%), and output duration lands within the input's own period-quantization noise of the expected value in every case.

## Tests

Adds `tests/slowdown_flush_test.c`, verified failing before this fix (short by ~15%, 21% trailing silence) and passing after.

## Test plan

- [x] `make test` — passes
- [x] `make CC=clang CFLAGS="-Wall -g -fsanitize=address,undefined -fno-omit-frame-pointer" test` — clean (only the separate, already-known `findSincCoefficient` finding, tracked in #67)
